### PR TITLE
feat: add Caspar media retry interval to config manifest

### DIFF
--- a/src/configManifest.ts
+++ b/src/configManifest.ts
@@ -49,6 +49,11 @@ const PLAYOUT_SUBDEVICE_CONFIG: SubDeviceConfigManifest['config'] = {
 			id: 'options.fps',
 			name: 'Frame rate',
 			type: ConfigManifestEntryType.NUMBER
+		},
+		{
+			id: 'options.retryInterval',
+			name: 'Media retry interval (ms), -1 disables, 0 default',
+			type: ConfigManifestEntryType.NUMBER
 		}
 	],
 	[TSRDeviceType.ATEM]: [


### PR DESCRIPTION
Adds Caspar media retry interval to config manifest. It is off by default (when undefined). 
-1 disables this functionality, 0 sets the interval to the default defined in TSR.
Requires https://github.com/olzzon/tv-automation-state-timeline-resolver/pull/19